### PR TITLE
[NOHARATEST-22] ユーザー認証のセッション切れ対応

### DIFF
--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,0 +1,93 @@
+"""セッション管理モジュール
+
+ユーザー認証のセッション切れを検知し、自動的にリフレッシュする機能を提供する。
+"""
+
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Session:
+    """ユーザーセッションを管理するクラス"""
+
+    user_id: str
+    token: str
+    created_at: float = field(default_factory=time.time)
+    expires_in: int = 3600  # デフォルト1時間
+    refresh_token: str = ""
+
+    @property
+    def is_expired(self) -> bool:
+        """セッションが期限切れかどうかを判定する"""
+        return time.time() > self.created_at + self.expires_in
+
+    @property
+    def remaining_seconds(self) -> float:
+        """セッションの残り時間（秒）を返す"""
+        remaining = (self.created_at + self.expires_in) - time.time()
+        return max(0, remaining)
+
+    def should_refresh(self, threshold: int = 300) -> bool:
+        """セッションのリフレッシュが必要かどうかを判定する
+
+        Args:
+            threshold: リフレッシュの閾値（秒）。デフォルトは5分前。
+        """
+        return self.remaining_seconds < threshold and not self.is_expired
+
+
+class SessionManager:
+    """セッションの生成・検証・リフレッシュを管理するクラス"""
+
+    def __init__(self, default_expires_in: int = 3600):
+        self._sessions: dict[str, Session] = {}
+        self._default_expires_in = default_expires_in
+
+    def create_session(self, user_id: str, token: str, refresh_token: str = "") -> Session:
+        """新しいセッションを作成する"""
+        session = Session(
+            user_id=user_id,
+            token=token,
+            expires_in=self._default_expires_in,
+            refresh_token=refresh_token,
+        )
+        self._sessions[user_id] = session
+        return session
+
+    def get_session(self, user_id: str) -> Session | None:
+        """ユーザーIDからセッションを取得する。期限切れの場合はNoneを返す。"""
+        session = self._sessions.get(user_id)
+        if session is None:
+            return None
+        if session.is_expired:
+            self.revoke_session(user_id)
+            return None
+        return session
+
+    def refresh_session(self, user_id: str, new_token: str) -> Session | None:
+        """セッションをリフレッシュする"""
+        session = self._sessions.get(user_id)
+        if session is None:
+            return None
+        refreshed = Session(
+            user_id=user_id,
+            token=new_token,
+            expires_in=self._default_expires_in,
+            refresh_token=session.refresh_token,
+        )
+        self._sessions[user_id] = refreshed
+        return refreshed
+
+    def revoke_session(self, user_id: str) -> None:
+        """セッションを無効化する"""
+        self._sessions.pop(user_id, None)
+
+    def cleanup_expired(self) -> int:
+        """期限切れのセッションを一括削除する。削除した件数を返す。"""
+        expired_users = [
+            uid for uid, session in self._sessions.items() if session.is_expired
+        ]
+        for uid in expired_users:
+            del self._sessions[uid]
+        return len(expired_users)

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -3,7 +3,9 @@
 ユーザー認証のセッション切れを検知し、自動的にリフレッシュする機能を提供する。
 """
 
+import threading
 import time
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 
@@ -26,23 +28,74 @@ class Session:
     def remaining_seconds(self) -> float:
         """セッションの残り時間（秒）を返す"""
         remaining = (self.created_at + self.expires_in) - time.time()
-        return max(0, remaining)
+        return max(0.0, remaining)
 
     def should_refresh(self, threshold: int = 300) -> bool:
         """セッションのリフレッシュが必要かどうかを判定する
 
+        is_expired が True の場合、remaining_seconds は 0 となるため
+        threshold > 0 であれば常にリフレッシュ対象となる。
+        期限切れセッションもリフレッシュ対象として扱う。
+
         Args:
             threshold: リフレッシュの閾値（秒）。デフォルトは5分前。
         """
-        return self.remaining_seconds < threshold and not self.is_expired
+        return self.remaining_seconds < threshold
+
+
+class AbstractSessionStore(ABC):
+    """セッションストアの抽象インターフェース"""
+
+    @abstractmethod
+    def get(self, user_id: str) -> Session | None:
+        """ユーザーIDからセッションを取得する"""
+
+    @abstractmethod
+    def set(self, user_id: str, session: Session) -> None:
+        """セッションを保存する"""
+
+    @abstractmethod
+    def delete(self, user_id: str) -> None:
+        """セッションを削除する"""
+
+    @abstractmethod
+    def all_sessions(self) -> dict[str, Session]:
+        """全セッションを返す"""
+
+
+class InMemorySessionStore(AbstractSessionStore):
+    """インメモリセッションストア"""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, Session] = {}
+
+    def get(self, user_id: str) -> Session | None:
+        return self._sessions.get(user_id)
+
+    def set(self, user_id: str, session: Session) -> None:
+        self._sessions[user_id] = session
+
+    def delete(self, user_id: str) -> None:
+        self._sessions.pop(user_id, None)
+
+    def all_sessions(self) -> dict[str, Session]:
+        return dict(self._sessions)
 
 
 class SessionManager:
-    """セッションの生成・検証・リフレッシュを管理するクラス"""
+    """セッションの生成・検証・リフレッシュを管理するクラス
 
-    def __init__(self, default_expires_in: int = 3600):
-        self._sessions: dict[str, Session] = {}
+    threading.Lock により並行アクセスを制御する。
+    """
+
+    def __init__(
+        self,
+        default_expires_in: int = 3600,
+        store: AbstractSessionStore | None = None,
+    ):
+        self._store = store or InMemorySessionStore()
         self._default_expires_in = default_expires_in
+        self._lock = threading.Lock()
 
     def create_session(self, user_id: str, token: str, refresh_token: str = "") -> Session:
         """新しいセッションを作成する"""
@@ -52,42 +105,58 @@ class SessionManager:
             expires_in=self._default_expires_in,
             refresh_token=refresh_token,
         )
-        self._sessions[user_id] = session
+        with self._lock:
+            self._store.set(user_id, session)
         return session
 
     def get_session(self, user_id: str) -> Session | None:
         """ユーザーIDからセッションを取得する。期限切れの場合はNoneを返す。"""
-        session = self._sessions.get(user_id)
-        if session is None:
-            return None
-        if session.is_expired:
-            self.revoke_session(user_id)
-            return None
-        return session
+        with self._lock:
+            session = self._store.get(user_id)
+            if session is None:
+                return None
+            if session.is_expired:
+                self._store.delete(user_id)
+                return None
+            return session
 
     def refresh_session(self, user_id: str, new_token: str) -> Session | None:
-        """セッションをリフレッシュする"""
-        session = self._sessions.get(user_id)
-        if session is None:
-            return None
-        refreshed = Session(
-            user_id=user_id,
-            token=new_token,
-            expires_in=self._default_expires_in,
-            refresh_token=session.refresh_token,
-        )
-        self._sessions[user_id] = refreshed
-        return refreshed
+        """セッションをリフレッシュする
+
+        期限切れセッションの場合は None を返し、リフレッシュしない。
+        """
+        with self._lock:
+            session = self._store.get(user_id)
+            if session is None:
+                return None
+            if session.is_expired:
+                self._store.delete(user_id)
+                return None
+            refreshed = Session(
+                user_id=user_id,
+                token=new_token,
+                expires_in=self._default_expires_in,
+                refresh_token=session.refresh_token,
+            )
+            self._store.set(user_id, refreshed)
+            return refreshed
 
     def revoke_session(self, user_id: str) -> None:
         """セッションを無効化する"""
-        self._sessions.pop(user_id, None)
+        with self._lock:
+            self._store.delete(user_id)
 
     def cleanup_expired(self) -> int:
-        """期限切れのセッションを一括削除する。削除した件数を返す。"""
-        expired_users = [
-            uid for uid, session in self._sessions.items() if session.is_expired
-        ]
-        for uid in expired_users:
-            del self._sessions[uid]
-        return len(expired_users)
+        """期限切れのセッションを一括削除する。削除した件数を返す。
+
+        revoke_session の内部ロジック（store.delete）を再利用する。
+        """
+        with self._lock:
+            expired_users = [
+                uid
+                for uid, session in self._store.all_sessions().items()
+                if session.is_expired
+            ]
+            for uid in expired_users:
+                self._store.delete(uid)
+            return len(expired_users)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,164 @@
+"""セッション管理モジュールの単体テスト"""
+
+import time
+
+import pytest
+
+from src.auth.session import (
+    InMemorySessionStore,
+    Session,
+    SessionManager,
+)
+
+
+# ---------- Session.is_expired ----------
+
+
+class TestSessionIsExpired:
+    def test_not_expired(self):
+        session = Session(user_id="u1", token="tok", expires_in=3600)
+        assert session.is_expired is False
+
+    def test_expired(self):
+        session = Session(
+            user_id="u1",
+            token="tok",
+            created_at=time.time() - 7200,
+            expires_in=3600,
+        )
+        assert session.is_expired is True
+
+    def test_just_expired(self):
+        """expires_in=0 のセッションは即座に期限切れとなる"""
+        session = Session(
+            user_id="u1",
+            token="tok",
+            created_at=time.time() - 1,
+            expires_in=0,
+        )
+        assert session.is_expired is True
+
+    def test_remaining_seconds_zero_when_expired(self):
+        session = Session(
+            user_id="u1",
+            token="tok",
+            created_at=time.time() - 7200,
+            expires_in=3600,
+        )
+        assert session.remaining_seconds == 0.0
+
+
+# ---------- Session.should_refresh ----------
+
+
+class TestSessionShouldRefresh:
+    def test_should_refresh_within_threshold(self):
+        session = Session(
+            user_id="u1",
+            token="tok",
+            created_at=time.time() - 3400,
+            expires_in=3600,
+        )
+        # remaining ~200s < threshold 300s
+        assert session.should_refresh(threshold=300) is True
+
+    def test_should_not_refresh_outside_threshold(self):
+        session = Session(user_id="u1", token="tok", expires_in=3600)
+        assert session.should_refresh(threshold=300) is False
+
+    def test_expired_session_should_refresh(self):
+        """期限切れセッションもリフレッシュ対象（remaining=0 < threshold）"""
+        session = Session(
+            user_id="u1",
+            token="tok",
+            created_at=time.time() - 7200,
+            expires_in=3600,
+        )
+        assert session.should_refresh(threshold=300) is True
+
+
+# ---------- SessionManager.get_session ----------
+
+
+class TestGetSession:
+    def test_get_existing_session(self):
+        mgr = SessionManager()
+        mgr.create_session("u1", "tok")
+        assert mgr.get_session("u1") is not None
+        assert mgr.get_session("u1").token == "tok"
+
+    def test_get_nonexistent_session(self):
+        mgr = SessionManager()
+        assert mgr.get_session("u1") is None
+
+    def test_get_expired_session_returns_none(self):
+        mgr = SessionManager(default_expires_in=0)
+        mgr.create_session("u1", "tok")
+        # expires_in=0 -> 即座に期限切れ
+        time.sleep(0.01)
+        assert mgr.get_session("u1") is None
+
+
+# ---------- SessionManager.refresh_session ----------
+
+
+class TestRefreshSession:
+    def test_refresh_valid_session(self):
+        mgr = SessionManager()
+        mgr.create_session("u1", "old_tok", refresh_token="rt")
+        refreshed = mgr.refresh_session("u1", "new_tok")
+        assert refreshed is not None
+        assert refreshed.token == "new_tok"
+        assert refreshed.refresh_token == "rt"
+
+    def test_refresh_nonexistent_session_returns_none(self):
+        mgr = SessionManager()
+        assert mgr.refresh_session("u1", "tok") is None
+
+    def test_refresh_expired_session_returns_none(self):
+        """期限切れセッションをリフレッシュしようとすると None を返す"""
+        mgr = SessionManager(default_expires_in=0)
+        mgr.create_session("u1", "tok")
+        time.sleep(0.01)
+        assert mgr.refresh_session("u1", "new_tok") is None
+
+
+# ---------- SessionManager.cleanup_expired ----------
+
+
+class TestCleanupExpired:
+    def test_cleanup_removes_expired(self):
+        mgr = SessionManager(default_expires_in=0)
+        mgr.create_session("u1", "tok1")
+        mgr.create_session("u2", "tok2")
+        time.sleep(0.01)
+        count = mgr.cleanup_expired()
+        assert count == 2
+
+    def test_cleanup_keeps_valid(self):
+        mgr = SessionManager(default_expires_in=3600)
+        mgr.create_session("u1", "tok1")
+        count = mgr.cleanup_expired()
+        assert count == 0
+
+
+# ---------- InMemorySessionStore ----------
+
+
+class TestInMemorySessionStore:
+    def test_crud_operations(self):
+        store = InMemorySessionStore()
+        session = Session(user_id="u1", token="tok")
+        store.set("u1", session)
+        assert store.get("u1") is session
+        store.delete("u1")
+        assert store.get("u1") is None
+
+    def test_all_sessions(self):
+        store = InMemorySessionStore()
+        s1 = Session(user_id="u1", token="t1")
+        s2 = Session(user_id="u2", token="t2")
+        store.set("u1", s1)
+        store.set("u2", s2)
+        all_s = store.all_sessions()
+        assert len(all_s) == 2


### PR DESCRIPTION
## Backlog 課題
- **課題キー**: NOHARATEST-22
- **URL**: https://comthink06.backlog.com/view/NOHARATEST-22
- **ブランチ**: `fix/NOHARATEST-22`

Closes #11

## 変更内容
- `should_refresh` から `and not self.is_expired` 条件を削除し、期限切れセッションもリフレッシュ対象として正しく判定されるよう修正
- `refresh_session` に `session.is_expired` チェックを追加し、期限切れセッションは `store.delete` して `None` を返すよう修正
- `threading.Lock` を追加し、全 public メソッド (`create_session`, `get_session`, `refresh_session`, `revoke_session`, `cleanup_expired`) を排他制御で保護
- `AbstractSessionStore` / `InMemorySessionStore` を新設し、DI でストア実装を差し替え可能に
- `cleanup_expired` を `store.delete` 直呼びに統一しデッドロックを回避
- 単体テスト 17 件を `tests/test_session.py` に追加

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `src/auth/session.py` | セッション管理の4つのバグ修正 + Store抽象化 + スレッドセーフ化 |
| `tests/__init__.py` | テストパッケージ初期化 |
| `tests/test_session.py` | 単体テスト17件追加 |

## 修正方針（Issue より）
> セッション管理の4つのバグ修正 + 構造改善（Store抽象化、スレッドセーフ化）+ テスト追加

## 担当者確認事項
- [ ] 変更内容が Issue の修正方針に沿っているか
- [ ] 不要な変更・ファイルが含まれていないか
- [ ] エッジケースの考慮漏れはないか
- [ ] セキュリティ上の問題はないか
- [ ] パフォーマンスへの悪影響はないか
- [ ] 既存テストが通ること

## 動作確認の観点
- 期限切れセッションの `should_refresh` が `True` を返すこと
- 期限切れセッションの `refresh_session` が `None` を返し、ストアから削除されること
- 期限切れセッションの `get_session` が `None` を返し、ストアから削除されること
- `cleanup_expired` がデッドロックせずに正常に動作すること
- `InMemorySessionStore` の CRUD 操作が正しく動作すること
- カスタムストア実装を DI で差し替え可能であること