### PR TITLE
[NOHARATEST-23] ダッシュボード画面のデザイン調整

### DIFF
--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -1,0 +1,162 @@
+/* ダッシュボード画面のスタイル定義 */
+
+:root {
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-bg: #f8fafc;
+  --color-card-bg: #ffffff;
+  --color-text: #1e293b;
+  --color-text-muted: #64748b;
+  --color-border: #e2e8f0;
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+  --radius: 8px;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+/* レイアウト */
+.dashboard {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  background-color: var(--color-bg);
+}
+
+.dashboard__sidebar {
+  background-color: var(--color-card-bg);
+  border-right: 1px solid var(--color-border);
+  padding: 24px 16px;
+}
+
+.dashboard__main {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+/* ヘッダー */
+.dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.dashboard__title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+/* カードグリッド */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.card {
+  background-color: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+}
+
+.card__label {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  margin-bottom: 8px;
+}
+
+.card__value {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+/* ステータスバッジ */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge--success {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.badge--warning {
+  background-color: #fef9c3;
+  color: #854d0e;
+}
+
+.badge--error {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+/* テーブル */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.table th {
+  background-color: var(--color-bg);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.table td {
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__sidebar {
+    display: none;
+  }
+
+  .dashboard__main {
+    padding: 16px;
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/dashboard/styles.css
+++ b/src/dashboard/styles.css
@@ -13,12 +13,29 @@
   --color-error: #ef4444;
   --radius: 8px;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --sidebar-width: 240px;
+  --spacing-xs: 8px;
+  --spacing-sm: 16px;
+  --spacing-md: 24px;
+  --spacing-lg: 32px;
+}
+
+/* ダークモード対応 */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #0f172a;
+    --color-card-bg: #1e293b;
+    --color-text: #f1f5f9;
+    --color-text-muted: #94a3b8;
+    --color-border: #334155;
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3);
+  }
 }
 
 /* レイアウト */
 .dashboard {
   display: grid;
-  grid-template-columns: 240px 1fr;
+  grid-template-columns: var(--sidebar-width) 1fr;
   min-height: 100vh;
   background-color: var(--color-bg);
 }
@@ -26,12 +43,17 @@
 .dashboard__sidebar {
   background-color: var(--color-card-bg);
   border-right: 1px solid var(--color-border);
-  padding: 24px 16px;
+  padding: var(--spacing-md) var(--spacing-sm);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
 }
 
 .dashboard__main {
-  padding: 32px;
+  padding: var(--spacing-lg);
   max-width: 1200px;
+  width: 100%;
 }
 
 /* ヘッダー */
@@ -39,7 +61,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 32px;
+  margin-bottom: var(--spacing-lg);
+  gap: var(--spacing-sm);
 }
 
 .dashboard__title {
@@ -47,39 +70,44 @@
   font-weight: 700;
   color: var(--color-text);
   margin: 0;
+  line-height: 1.25;
 }
 
 /* カードグリッド */
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 24px;
-  margin-bottom: 32px;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
 }
 
 .card {
   background-color: var(--color-card-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  padding: 24px;
+  padding: var(--spacing-md);
   box-shadow: var(--shadow);
-  transition: box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .card:hover {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
 }
 
 .card__label {
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--color-text-muted);
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-xs);
+  letter-spacing: 0.01em;
 }
 
 .card__value {
-  font-size: 32px;
+  font-size: 28px;
   font-weight: 700;
   color: var(--color-text);
+  line-height: 1.2;
 }
 
 /* ステータスバッジ */
@@ -90,6 +118,7 @@
   border-radius: 9999px;
   font-size: 12px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .badge--success {
@@ -105,6 +134,24 @@
 .badge--error {
   background-color: #fee2e2;
   color: #991b1b;
+}
+
+/* ダークモード時のバッジ調整 */
+@media (prefers-color-scheme: dark) {
+  .badge--success {
+    background-color: #14532d;
+    color: #86efac;
+  }
+
+  .badge--warning {
+    background-color: #713f12;
+    color: #fde68a;
+  }
+
+  .badge--error {
+    background-color: #7f1d1d;
+    color: #fca5a5;
+  }
 }
 
 /* テーブル */
@@ -142,7 +189,27 @@
   border-bottom: none;
 }
 
-/* レスポンシブ対応 */
+.table tbody tr:hover {
+  background-color: var(--color-bg);
+}
+
+/* レスポンシブ対応: タブレット (769px - 1024px) */
+@media (min-width: 769px) and (max-width: 1024px) {
+  :root {
+    --sidebar-width: 200px;
+  }
+
+  .dashboard__main {
+    padding: var(--spacing-md);
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: var(--spacing-sm);
+  }
+}
+
+/* レスポンシブ対応: モバイル (max 768px) */
 @media (max-width: 768px) {
   .dashboard {
     grid-template-columns: 1fr;
@@ -153,10 +220,30 @@
   }
 
   .dashboard__main {
-    padding: 16px;
+    padding: var(--spacing-sm);
+  }
+
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-bottom: var(--spacing-md);
+  }
+
+  .dashboard__title {
+    font-size: 20px;
   }
 
   .card-grid {
     grid-template-columns: 1fr;
+    gap: var(--spacing-sm);
+  }
+
+  .card__value {
+    font-size: 24px;
+  }
+
+  .table th,
+  .table td {
+    padding: 10px 12px;
   }
 }


### PR DESCRIPTION
## Backlog 課題

- **課題キー**: NOHARATEST-23
- **URL**: https://comthink06.backlog.com/view/NOHARATEST-23
- **ブランチ**: `fix/NOHARATEST-23`

Closes #6

## 変更内容

- ダークモード対応: `prefers-color-scheme: dark` による CSS 変数の上書きを追加し、背景・テキスト・ボーダー色をダークテーマに対応
- バッジ（success / warning / error）のダークモード時の配色を調整
- スペーシングを CSS 変数（`--spacing-xs/sm/md/lg`）に統一し、一貫性を確保
- サイドバーに `position: sticky` と `overflow-y: auto` を追加してスクロール時の固定表示を実現
- タブレットサイズ（769px〜1024px）向けのレスポンシブ対応を追加
- モバイル時のヘッダーを縦並びに変更し、タイトルフォントサイズを最適化
- カード値フォントサイズを 32px → 28px に調整（視認性向上）
- テーブル行にホバー時の背景色追加
- カードホバーに `transform: translateY(-1px)` を追加してインタラクションを向上

## 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `src/dashboard/styles.css` | ダークモード対応、レスポンシブ改善、スペーシング変数化、スタイル調整 |

## 修正方針（Issue より）

> 1. `src/dashboard/styles.css` のレイアウト・スタイルを調整（カード配置、余白、フォントサイズ等）
> 2. レスポンシブ対応の確認・改善
> 3. ダークモード対応の整合性確認
> 4. グローバルスタイルとの競合がないか確認

## 担当者確認事項

- [ ] 変更内容が Issue の修正方針に沿っているか
- [ ] 不要な変更・ファイルが含まれていないか
- [ ] エッジケースの考慮漏れはないか
- [ ] セキュリティ上の問題はないか
- [ ] パフォーマンスへの悪影響はないか
- [ ] 既存テストが通ること

## 動作確認の観点

- [ ] ライトモード時にダッシュボードのカード・テーブル・バッジが正しい配色で表示されること
- [ ] ダークモード（OS 設定）に切り替えた際、背景・テキスト・ボーダーが適切なダーク配色に切り替わること
- [ ] 画面幅 1024px 以下（タブレット）でサイドバー幅が縮小され、カードが適切に並ぶこと
- [ ] 画面幅 768px 以下（モバイル）でサイドバーが非表示になり、カードが 1 列表示になること
- [ ] モバイル時にヘッダーが縦並びになり、タイトルが正しいフォントサイズで表示されること
- [ ] サイドバーが長いコンテンツでスクロール可能で、かつ画面に固定されること